### PR TITLE
Make options non case sensitive for Bash edition 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ AVAILABLE OPTIONS:
         help - show this help.
         version - show version and about information.
 
-options are not case sensitive (C edition only).
+options are not case sensitive.
 ```
 ## Learning mode:
 ### using a configuration file

--- a/bash-edition/aptpac.sh
+++ b/bash-edition/aptpac.sh
@@ -127,7 +127,7 @@ while [[ "$1" != '' ]]; do
 			LEARN=1
 		;;
 	esac
-	case $1 in
+	case ${1,,} in
 		--learning-mode*)
 			MODE=$(echo $1 | sed -e 's/^[^=]*=//g')
 			if [[ "$MODE" == "on" ]]; then


### PR DESCRIPTION
Make options non case sensitive for Bash edition.
As per https://wiki.bash-hackers.org/syntax/pe#case_modification