### PR TITLE
Fix the error on initial run on new installation

### DIFF
--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -124,7 +124,7 @@ void config_load(struct config *config) {
 #ifdef DEBUG
 	debug("configuration file", conf_file);
 #endif
-	file=fopen(conf_file, "r");
+	file=fopen(conf_file, "a+");
 	if(file==NULL) {
 		fprintf(stderr, "config_load(): fopen(): %s: %s\n", strerror(errno), conf_file);
 		exit(-1);

--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -56,7 +56,8 @@ void help(char *argv0) {
 	println("\e[1mCONFIGURATION:\e[0m");
 	println("	--config <set|unset> <configuration> - set/unset configuration options.");
 	println("\e[1mAVAILABLE CONFIGURATION OPTIONS:\e[0m");
-	println("	learn");
+	println("	learn (default: off)");
+	println("	Configuration is default if there is not a config file yet.");
 	println("\e[1moptions are not case sensitive.\e[0m");
 }
  
@@ -125,13 +126,11 @@ void config_load(struct config *config) {
 	debug("configuration file", conf_file);
 #endif
 	file=fopen(conf_file, "r");
-	if(file==NULL){
-		fprintf(stderr, "Configuration file does not exist, trying to create it.\n");
-		file=fopen(conf_file, "a+");
-		if(file==NULL){
-			fprintf(stderr, "config_load(): Failed to create config file at %s. %s\n", conf_file, strerror(errno));
-			exit(-1);
-		}
+	if(file==NULL) {
+		// There is not a config file, learning mode is default off.
+		config->version = CONF_FILE_VERSION;
+		config->learn = 0;
+		return;
 	}
 	fread(config, sizeof(struct config), 1, file);
 	if(config->version!=CONF_FILE_VERSION) {

--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -129,7 +129,7 @@ void config_load(struct config *config) {
 		fprintf(stderr, "Configuration file does not exist, trying to create it.\n");
 		file=fopen(conf_file, "a+");
 		if(file==NULL){
-			fprintf(stderr, "config_load(): Failed to create config file ay %s: %s\n", conf_file, strerror(errno));
+			fprintf(stderr, "config_load(): Failed to create config file at %s. %s\n", conf_file, strerror(errno));
 			exit(-1);
 		}
 	}

--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -124,10 +124,14 @@ void config_load(struct config *config) {
 #ifdef DEBUG
 	debug("configuration file", conf_file);
 #endif
-	file=fopen(conf_file, "a+");
-	if(file==NULL) {
-		fprintf(stderr, "config_load(): fopen(): %s: %s\n", strerror(errno), conf_file);
-		exit(-1);
+	file=fopen(conf_file, "r");
+	if(file==NULL){
+		fprintf(stderr, "Configuration file does not exist, trying to create it.\n");
+		file=fopen(conf_file, "a+");
+		if(file==NULL){
+			fprintf(stderr, "config_load(): Failed to create config file ay %s: %s\n", conf_file, strerror(errno));
+			exit(-1);
+		}
 	}
 	fread(config, sizeof(struct config), 1, file);
 	if(config->version!=CONF_FILE_VERSION) {

--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -127,7 +127,7 @@ void config_load(struct config *config) {
 #endif
 	file=fopen(conf_file, "r");
 	if(file==NULL) {
-		// There is not a config file, learning mode is default off.
+		// There is no config file, set the configuration values to the defaults.
 		config->version = CONF_FILE_VERSION;
 		config->learn = 0;
 		return;

--- a/C-edition/src/functions.c
+++ b/C-edition/src/functions.c
@@ -57,7 +57,7 @@ void help(char *argv0) {
 	println("	--config <set|unset> <configuration> - set/unset configuration options.");
 	println("\e[1mAVAILABLE CONFIGURATION OPTIONS:\e[0m");
 	println("	learn (default: off)");
-	println("	Configuration is default if there is not a config file yet.");
+	println("	Configuration is set to the default values if there is no configuration file.");
 	println("\e[1moptions are not case sensitive.\e[0m");
 }
  


### PR DESCRIPTION
On a new installation, the programme will attempt to read the config file which yet does not exisit, causing the error `config_load: fopen: No such file or directory`.