### PR TITLE
Handle empty autoremove properly

### DIFF
--- a/C-edition/src/main.c
+++ b/C-edition/src/main.c
@@ -178,7 +178,11 @@ int main(int argc, char **argv) {
 			break;
 		} else if(!strcasecmp(argv[1], "autoremove")) {
 			learn("sudo pacman -Qdtq | sudo pacman -Rs -", LEARN);
-			system("sudo pacman -Qdtq | sudo pacman -Rs -");
+			if(system("test \"x$(pacman -Qdtq)\" = x")){
+				system("sudo pacman -Qdtq | sudo pacman -Rs -");
+			}else{
+				printf("Nothing to be autoremoved.\n");
+			}
 			break;
 		} else if(!strcasecmp(argv[1], "list-installed")) {
 			learn(command, LEARN);

--- a/C-edition/src/main.c
+++ b/C-edition/src/main.c
@@ -178,10 +178,10 @@ int main(int argc, char **argv) {
 			break;
 		} else if(!strcasecmp(argv[1], "autoremove")) {
 			learn("sudo pacman -Qdtq | sudo pacman -Rs -", LEARN);
-			if(system("test \"x$(pacman -Qdtq)\" = x")){
-				system("sudo pacman -Qdtq | sudo pacman -Rs -");
-			}else{
-				printf("Nothing to be autoremoved.\n");
+			if(system("test -z \"$(pacman -Qdtq)\"") == 0) {
+				puts("Nothing to autoremove.");
+			} else {
+				system("pacman -Qdtq | sudo pacman -Rs -");
 			}
 			break;
 		} else if(!strcasecmp(argv[1], "list-installed")) {


### PR DESCRIPTION
When there is not unneeded dependencies to remove, we will encounter:

```
$ aptpac autoremove
error: argument '-' specified with empty stdin
```

It looks weird and abrupt.

I modified it so that it can detect if there is a need to run `pacman -R`:

## Test

If there is something to remove, it works as it did in the past:

```
$ aptpac autoremove                            
checking dependencies...

Packages (2) qoauth-2.0.0-3  qt5-xmlpatterns-5.15.6+kde+r0-1

Total Removed Size:  6.77 MiB

:: Do you want to remove these packages? [Y/n] 
```

After the command above, run it again:

```
$ aptpac autoremove
Nothing to be autoremoved.
```

There will be a friendly prompt.